### PR TITLE
fix: disable tap gesture on message view upon message request error

### DIFF
--- a/Sources/PayPalMessages/PayPalMessageViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageViewModel.swift
@@ -86,9 +86,7 @@ class PayPalMessageViewModel: PayPalMessageModalEventDelegate {
     }
 
     /// Update the messageView's interactivity based on the boolean flag. Disabled by default.
-    var isMessageViewInteractive = false {
-        didSet { messageView?.isUserInteractionEnabled = isMessageViewInteractive }
-    }
+    var isMessageViewInteractive = false
 
     /// returns the parameters for the style and content the message's Attributed String according to the server response
     var messageParameters: PayPalMessageViewParameters? { makeViewParameters() }


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

- Disables the tap gesture on the message view when a request fails in order to prevent the user from opening the modal in these cases.

## Screenshots

N/A

## Testing instructions

