### PR TITLE
fix: unrecoverable error state after supplying valid client id

### DIFF
--- a/Sources/PayPalMessages/PayPalMessageViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageViewModel.swift
@@ -172,6 +172,7 @@ class PayPalMessageViewModel: PayPalMessageModalEventDelegate {
     deinit {}
 
     private func updateConfig(_ config: PayPalMessageConfig) {
+        self.clientID = config.data.clientID
         self.amount = config.data.amount
         self.placement = config.data.placement
         self.offerType = config.data.offerType


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description
- The initial Client ID `YOUR_CLIENT_ID` causes the message to not render from invalid credentials; however, after supplying a valid Client ID the message doesn't update. This PR fixes this behavior so that upon supplying a valid Client ID, the message renders correctly.

## Screenshots

N/A

## Testing instructions

N/A
