### PR TITLE
fix: message and modal accessibility

### DIFF
--- a/Demo/Demo/UIKitContentViewController.swift
+++ b/Demo/Demo/UIKitContentViewController.swift
@@ -110,18 +110,7 @@ class UIKitContentViewController: UIViewController {
     }()
 
     lazy var stackView: UIStackView = {
-        let paypalMessageContainer = UIView()
-
-        paypalMessageContainer.addSubview(paypalMessage)
-
         paypalMessage.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            paypalMessage.leadingAnchor.constraint(equalTo: paypalMessageContainer.leadingAnchor),
-            paypalMessage.trailingAnchor.constraint(equalTo: paypalMessageContainer.trailingAnchor),
-            paypalMessage.topAnchor.constraint(equalTo: paypalMessageContainer.topAnchor),
-            paypalMessage.bottomAnchor.constraint(equalTo: paypalMessageContainer.bottomAnchor, constant: 20)
-        ])
-
 
         return getStackView(
             subviews: [
@@ -174,7 +163,7 @@ class UIKitContentViewController: UIViewController {
                     axis: .horizontal
                 ),
                 getSeparator(),
-                paypalMessageContainer
+                paypalMessage
             ],
             padding: 12
         )

--- a/Sources/PayPalMessages/PayPalMessageModal.swift
+++ b/Sources/PayPalMessages/PayPalMessageModal.swift
@@ -165,7 +165,6 @@ final class PayPalMessageModal: UIViewController, WKUIDelegate {
     // MARK: - Config Functions
 
     private func configViews() {
-        view.accessibilityLabel = "PayPal Learn More Modal"
         // FIXME: Prevent this click from applying to the core modal body
         view.addGestureRecognizer(
             UITapGestureRecognizer(target: self, action: #selector(self.hide))

--- a/Sources/PayPalMessages/PayPalMessageModal.swift
+++ b/Sources/PayPalMessages/PayPalMessageModal.swift
@@ -165,6 +165,7 @@ final class PayPalMessageModal: UIViewController, WKUIDelegate {
     // MARK: - Config Functions
 
     private func configViews() {
+        view.accessibilityLabel = "PayPal Learn More Modal"
         // FIXME: Prevent this click from applying to the core modal body
         view.addGestureRecognizer(
             UITapGestureRecognizer(target: self, action: #selector(self.hide))
@@ -258,6 +259,8 @@ final class PayPalMessageModal: UIViewController, WKUIDelegate {
         }
 
         closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.isAccessibilityElement = true
+        closeButton.accessibilityLabel = "PayPal Learn More Modal Close"
 
         view.addSubview(closeButton)
 

--- a/Sources/PayPalMessages/PayPalMessageView.swift
+++ b/Sources/PayPalMessages/PayPalMessageView.swift
@@ -254,9 +254,9 @@ extension PayPalMessageView {
     }
 
     private func configAccessibility() {
-        accessibilityTraits = .link
+        accessibilityTraits = .button
         isAccessibilityElement = true
-        accessibilityLabel = Constants.accessibilityLabel
+        accessibilityLabel = viewModel.messageView?.accessibilityLabel
     }
 }
 
@@ -265,7 +265,6 @@ extension PayPalMessageView {
 extension PayPalMessageView {
 
     private enum Constants {
-        static let accessibilityLabel: String = "PayPalMessageView"
         static let highlightedAnimationDuration: CGFloat = 1.0
         static let highlightedAlpha: CGFloat = 0.75
         static let regularAlpha: CGFloat = 1.0

--- a/Sources/PayPalMessages/PayPalMessageView.swift
+++ b/Sources/PayPalMessages/PayPalMessageView.swift
@@ -160,7 +160,7 @@ public final class PayPalMessageView: UIControl {
 
     override public func awakeFromNib() {
         super.awakeFromNib()
-        refreshContent()
+        refreshContent(label: accessibilityLabel ?? "", traits: accessibilityTraits, accessibilityElement: isAccessibilityElement)
     }
 
     override public var intrinsicContentSize: CGSize {
@@ -235,11 +235,16 @@ public final class PayPalMessageView: UIControl {
 extension PayPalMessageView: PayPalMessageViewModelDelegate {
 
     /// Recreates the message content from the existing data. **Does not triggers a networking event.**
-    func refreshContent() {
+    func refreshContent(label: String, traits: UIAccessibilityTraits, accessibilityElement: Bool) {
         let params = viewModel.messageParameters
         messageLabel.attributedText = PayPalMessageAttributedStringBuilder().makeMessageString(params)
         // Force recalculation for layout
         invalidateIntrinsicContentSize()
+
+        // Update accessibility properties
+        self.accessibilityLabel = label
+        self.accessibilityTraits = traits
+        self.isAccessibilityElement = accessibilityElement
     }
 }
 
@@ -250,13 +255,12 @@ extension PayPalMessageView {
     /// Called when the accessibility or orientation traits have changed. Reloads the content accordingly.
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        refreshContent()
+        refreshContent(label: accessibilityLabel ?? "", traits: accessibilityTraits, accessibilityElement: isAccessibilityElement)
     }
 
     private func configAccessibility() {
         accessibilityTraits = .button
         isAccessibilityElement = true
-        accessibilityLabel = viewModel.messageView?.accessibilityLabel
     }
 }
 

--- a/Sources/PayPalMessages/PayPalMessageView.swift
+++ b/Sources/PayPalMessages/PayPalMessageView.swift
@@ -160,7 +160,7 @@ public final class PayPalMessageView: UIControl {
 
     override public func awakeFromNib() {
         super.awakeFromNib()
-        refreshContent(label: accessibilityLabel ?? "", traits: accessibilityTraits, accessibilityElement: isAccessibilityElement)
+        refreshContent()
     }
 
     override public var intrinsicContentSize: CGSize {
@@ -235,16 +235,16 @@ public final class PayPalMessageView: UIControl {
 extension PayPalMessageView: PayPalMessageViewModelDelegate {
 
     /// Recreates the message content from the existing data. **Does not triggers a networking event.**
-    func refreshContent(label: String, traits: UIAccessibilityTraits, accessibilityElement: Bool) {
+    func refreshContent() {
         let params = viewModel.messageParameters
         messageLabel.attributedText = PayPalMessageAttributedStringBuilder().makeMessageString(params)
         // Force recalculation for layout
         invalidateIntrinsicContentSize()
 
         // Update accessibility properties
-        self.accessibilityLabel = label
-        self.accessibilityTraits = traits
-        self.isAccessibilityElement = accessibilityElement
+        self.accessibilityLabel = params?.accessibilityLabel ?? ""
+        self.accessibilityTraits = params?.accessibilityTraits ?? .none
+        self.isAccessibilityElement = params?.isAccessibilityElement ?? false
     }
 }
 
@@ -255,12 +255,12 @@ extension PayPalMessageView {
     /// Called when the accessibility or orientation traits have changed. Reloads the content accordingly.
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        refreshContent(label: accessibilityLabel ?? "", traits: accessibilityTraits, accessibilityElement: isAccessibilityElement)
+        refreshContent()
     }
 
     private func configAccessibility() {
-        accessibilityTraits = .button
-        isAccessibilityElement = true
+        accessibilityTraits = .none
+        isAccessibilityElement = false
     }
 }
 

--- a/Sources/PayPalMessages/PayPalMessageView.swift
+++ b/Sources/PayPalMessages/PayPalMessageView.swift
@@ -188,7 +188,6 @@ public final class PayPalMessageView: UIControl {
         addSubview(containerView)
 
         configConstraints()
-        configAccessibility()
     }
 
     private func configConstraints() {
@@ -256,11 +255,6 @@ extension PayPalMessageView {
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         refreshContent()
-    }
-
-    private func configAccessibility() {
-        accessibilityTraits = .none
-        isAccessibilityElement = false
     }
 }
 

--- a/Sources/PayPalMessages/PayPalMessageViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageViewModel.swift
@@ -268,6 +268,11 @@ class PayPalMessageViewModel: PayPalMessageModalEventDelegate {
         // Disable the tap gesture
         isMessageViewInteractive = false
 
+        // Update accessibility properties
+        self.messageView?.accessibilityLabel = ""
+        self.messageView?.accessibilityTraits = .none
+        self.messageView?.isAccessibilityElement = false
+
         delegate?.refreshContent()
     }
 
@@ -291,6 +296,21 @@ class PayPalMessageViewModel: PayPalMessageModalEventDelegate {
 
         // Enable the tap gesture
         isMessageViewInteractive = true
+
+        // Creates a new sanitized string for use as the accessibilityLabel
+        let sanitizedMainContent = response.defaultMainContent
+            .replacingOccurrences(of: "%paypal_logo%", with: "PayPal")
+            .replacingOccurrences(of: "/mo", with: " per month")
+
+        var accessibilityLabel = sanitizedMainContent
+
+        if !sanitizedMainContent.contains("PayPal") {
+            accessibilityLabel = "PayPal, " + accessibilityLabel
+        }
+
+        accessibilityLabel += " \(response.defaultDisclaimer)"
+
+        self.messageView?.accessibilityLabel = accessibilityLabel
 
         modal?.setConfig(makeModalConfig())
 

--- a/Sources/PayPalMessages/PayPalMessageViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageViewModel.swift
@@ -325,7 +325,7 @@ class PayPalMessageViewModel: PayPalMessageModalEventDelegate {
         return parameterBuilder
             .makeParameters(
                 message: response.defaultMainContent,
-                offerType: response.offerType.rawValue,
+                offerType: response.offerType,
                 linkDescription: response.defaultDisclaimer,
                 logoPlaceholder: response.logoPlaceholder,
                 logoType: logoType,

--- a/Sources/PayPalMessages/PayPalMessageViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageViewModel.swift
@@ -299,7 +299,7 @@ class PayPalMessageViewModel: PayPalMessageModalEventDelegate {
 
         // Creates a new sanitized string for use as the accessibilityLabel
         let sanitizedMainContent = response.defaultMainContent
-            .replacingOccurrences(of: "%paypal_logo%", with: "PayPal")
+            .replacingOccurrences(of: "%paypal_logo%", with: response.offerType == PayPalMessageResponseOfferType.payPalCreditNoInterest ? "PayPal Credit" : "PayPal")
             .replacingOccurrences(of: "/mo", with: " per month")
 
         var accessibilityLabel = sanitizedMainContent

--- a/Sources/PayPalMessages/PayPalMessageViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageViewModel.swift
@@ -305,7 +305,7 @@ class PayPalMessageViewModel: PayPalMessageModalEventDelegate {
         var accessibilityLabel = sanitizedMainContent
 
         if !sanitizedMainContent.contains("PayPal") {
-            accessibilityLabel = "PayPal, " + accessibilityLabel
+            accessibilityLabel = "PayPal - " + accessibilityLabel
         }
 
         accessibilityLabel += " \(response.defaultDisclaimer)"

--- a/Sources/PayPalMessages/Utils/PayPalMessageViewParameters.swift
+++ b/Sources/PayPalMessages/Utils/PayPalMessageViewParameters.swift
@@ -15,4 +15,8 @@ struct PayPalMessageViewParameters {
     let linkUnderlineColor: UIColor
 
     let textAlignment: NSTextAlignment
+
+    let accessibilityLabel: String
+    let accessibilityTraits: UIAccessibilityTraits
+    let isAccessibilityElement: Bool
 }

--- a/Sources/PayPalMessages/Utils/PayPalMessageViewParametersBuilder.swift
+++ b/Sources/PayPalMessages/Utils/PayPalMessageViewParametersBuilder.swift
@@ -5,6 +5,7 @@ struct PayPalMessageViewParametersBuilder {
     // swiftlint:disable:next function_parameter_count
     func makeParameters(
         message: String,
+        offerType: String,
         linkDescription: String,
         logoPlaceholder: String,
         logoType: PayPalMessageLogoType,
@@ -23,6 +24,27 @@ struct PayPalMessageViewParametersBuilder {
             productGroup: productGroup
         )
 
+
+        // Creates a new sanitized string for use as the accessibilityLabel
+        let sanitizedMainContent = message
+            .replacingOccurrences(
+                of: "%paypal_logo%",
+                with: offerType == PayPalMessageResponseOfferType.payPalCreditNoInterest.rawValue ? "PayPal Credit" : "PayPal"
+            )
+            .replacingOccurrences(of: "/mo", with: " per month")
+
+        var accessibilityLabel = sanitizedMainContent
+
+        if !sanitizedMainContent.contains("PayPal Credit") && !sanitizedMainContent.contains("PayPal") {
+            if offerType == PayPalMessageResponseOfferType.payPalCreditNoInterest.rawValue {
+                accessibilityLabel = "PayPal Credit - " + accessibilityLabel
+            } else {
+                accessibilityLabel = "PayPal - " + accessibilityLabel
+            }
+        }
+
+        accessibilityLabel += " \(linkDescription)"
+
         return PayPalMessageViewParameters(
             message: message,
             messageColor: getLabelColor(payPalColor),
@@ -33,7 +55,10 @@ struct PayPalMessageViewParametersBuilder {
             linkDescription: linkDescription,
             linkColor: getLinkColor(payPalColor),
             linkUnderlineColor: getUnderlineLinkColor(payPalColor),
-            textAlignment: getAlignment(payPalAlignment)
+            textAlignment: getAlignment(payPalAlignment),
+            accessibilityLabel: accessibilityLabel,
+            accessibilityTraits: .button,
+            isAccessibilityElement: true
         )
     }
 

--- a/Sources/PayPalMessages/Utils/PayPalMessageViewParametersBuilder.swift
+++ b/Sources/PayPalMessages/Utils/PayPalMessageViewParametersBuilder.swift
@@ -35,7 +35,7 @@ struct PayPalMessageViewParametersBuilder {
 
         var accessibilityLabel = sanitizedMainContent
 
-        if !sanitizedMainContent.contains("PayPal Credit") && !sanitizedMainContent.contains("PayPal") {
+        if !sanitizedMainContent.contains("PayPal") {
             if offerType == .payPalCreditNoInterest {
                 accessibilityLabel = "PayPal Credit - " + accessibilityLabel
             } else {

--- a/Sources/PayPalMessages/Utils/PayPalMessageViewParametersBuilder.swift
+++ b/Sources/PayPalMessages/Utils/PayPalMessageViewParametersBuilder.swift
@@ -5,7 +5,7 @@ struct PayPalMessageViewParametersBuilder {
     // swiftlint:disable:next function_parameter_count
     func makeParameters(
         message: String,
-        offerType: String,
+        offerType: PayPalMessageResponseOfferType,
         linkDescription: String,
         logoPlaceholder: String,
         logoType: PayPalMessageLogoType,
@@ -28,22 +28,22 @@ struct PayPalMessageViewParametersBuilder {
         // Creates a new sanitized string for use as the accessibilityLabel
         let sanitizedMainContent = message
             .replacingOccurrences(
-                of: "%paypal_logo%",
-                with: offerType == PayPalMessageResponseOfferType.payPalCreditNoInterest.rawValue ? "PayPal Credit" : "PayPal"
+                of: logoPlaceholder,
+                with: offerType == .payPalCreditNoInterest ? "PayPal Credit" : "PayPal"
             )
             .replacingOccurrences(of: "/mo", with: " per month")
 
         var accessibilityLabel = sanitizedMainContent
 
         if !sanitizedMainContent.contains("PayPal Credit") && !sanitizedMainContent.contains("PayPal") {
-            if offerType == PayPalMessageResponseOfferType.payPalCreditNoInterest.rawValue {
+            if offerType == .payPalCreditNoInterest {
                 accessibilityLabel = "PayPal Credit - " + accessibilityLabel
             } else {
                 accessibilityLabel = "PayPal - " + accessibilityLabel
             }
         }
 
-        accessibilityLabel += " \(linkDescription)"
+        accessibilityLabel = accessibilityLabel + " " + linkDescription
 
         return PayPalMessageViewParameters(
             message: message,

--- a/Tests/PayPalMessagesTests/Mocks/PayPalMessageViewMock.swift
+++ b/Tests/PayPalMessagesTests/Mocks/PayPalMessageViewMock.swift
@@ -7,7 +7,7 @@ class PayPalMessageViewMock: PayPalMessageViewModelDelegate {
     weak var viewModel: PayPalMessageViewModel?
     var refreshContentCalled = false
 
-    func refreshContent(label: String, traits: UIAccessibilityTraits, accessibilityElement: Bool) {
+    func refreshContent() {
         refreshContentCalled = true
     }
 }

--- a/Tests/PayPalMessagesTests/Mocks/PayPalMessageViewMock.swift
+++ b/Tests/PayPalMessagesTests/Mocks/PayPalMessageViewMock.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 @testable import PayPalMessages
 
 class PayPalMessageViewMock: PayPalMessageViewModelDelegate {

--- a/Tests/PayPalMessagesTests/Mocks/PayPalMessageViewMock.swift
+++ b/Tests/PayPalMessagesTests/Mocks/PayPalMessageViewMock.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 @testable import PayPalMessages
 
 class PayPalMessageViewMock: PayPalMessageViewModelDelegate {
@@ -6,7 +7,7 @@ class PayPalMessageViewMock: PayPalMessageViewModelDelegate {
     weak var viewModel: PayPalMessageViewModel?
     var refreshContentCalled = false
 
-    func refreshContent() {
+    func refreshContent(label: String, traits: UIAccessibilityTraits, accessibilityElement: Bool) {
         refreshContentCalled = true
     }
 }

--- a/Tests/PayPalMessagesTests/PayPalMessageAttributedStringTests.swift
+++ b/Tests/PayPalMessagesTests/PayPalMessageAttributedStringTests.swift
@@ -31,7 +31,10 @@ final class PayPalMessageAttributedStringTests: XCTestCase {
             linkDescription: testLinkDescription,
             linkColor: .blue,
             linkUnderlineColor: .blue,
-            textAlignment: .left
+            textAlignment: .left,
+            accessibilityLabel: "Pay in several installments with PayPal. Learn More",
+            accessibilityTraits: .button,
+            isAccessibilityElement: true
         )
     }
 

--- a/Tests/PayPalMessagesTests/PayPalMessageLogoTests.swift
+++ b/Tests/PayPalMessagesTests/PayPalMessageLogoTests.swift
@@ -14,7 +14,7 @@ final class PayPalMessageLogoTests: XCTestCase {
     ) {
         let resultParameter = paramsBuilder.makeParameters(
             message: "",
-            offerType: PayPalMessageOfferType.payLaterShortTerm.rawValue,
+            offerType: PayPalMessageResponseOfferType.payLaterShortTerm,
             linkDescription: "",
             logoPlaceholder: "",
             logoType: logoType,
@@ -262,7 +262,7 @@ final class PayPalMessageLogoTests: XCTestCase {
             for productGroup in allProductGroups {
                 let resultParameter = paramsBuilder.makeParameters(
                     message: "",
-                    offerType: PayPalMessageOfferType.payLaterShortTerm.rawValue,
+                    offerType: PayPalMessageResponseOfferType.payLaterShortTerm,
                     linkDescription: "",
                     logoPlaceholder: "",
                     logoType: .none,

--- a/Tests/PayPalMessagesTests/PayPalMessageLogoTests.swift
+++ b/Tests/PayPalMessagesTests/PayPalMessageLogoTests.swift
@@ -14,6 +14,7 @@ final class PayPalMessageLogoTests: XCTestCase {
     ) {
         let resultParameter = paramsBuilder.makeParameters(
             message: "",
+            offerType: PayPalMessageOfferType.payLaterShortTerm.rawValue,
             linkDescription: "",
             logoPlaceholder: "",
             logoType: logoType,
@@ -261,6 +262,7 @@ final class PayPalMessageLogoTests: XCTestCase {
             for productGroup in allProductGroups {
                 let resultParameter = paramsBuilder.makeParameters(
                     message: "",
+                    offerType: PayPalMessageOfferType.payLaterShortTerm.rawValue,
                     linkDescription: "",
                     logoPlaceholder: "",
                     logoType: .none,

--- a/Tests/PayPalMessagesTests/PayPalMessageViewTests.swift
+++ b/Tests/PayPalMessagesTests/PayPalMessageViewTests.swift
@@ -37,17 +37,4 @@ class PayPalMessageViewTests: XCTestCase {
         XCTAssertEqual(messageView.clientID, config.data.clientID)
         XCTAssertEqual(messageView.color, config.style.color)
     }
-
-    func testConfigAccessibility() {
-        let config = config
-
-        let messageView = PayPalMessageView(
-            config: config
-        )
-
-        // Assert accessibility properties are correctly initialized
-        XCTAssertEqual(messageView.accessibilityTraits, .link)
-        XCTAssertTrue(messageView.isAccessibilityElement)
-        XCTAssertEqual(messageView.accessibilityLabel, Constants.accessibilityLabel)
-    }
 }


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

- Adds relevant accessibility properties (i.e. VoiceOver now reads out contents of the message, modal close button is now read correctly, etc.)
#### Misc. fix (unrelated to A11y audit):
- Fixed UIKit demo app where you could only tap on the message in a very particular spot to get the modal webview to open.

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

**Xcode > Open Developer Tool > Accessibility Inspector**