### PR TITLE
fix: correctly init AnyCodable for modal event properties

### DIFF
--- a/Sources/PayPalMessages/PayPalMessageModalViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageModalViewModel.swift
@@ -261,7 +261,7 @@ class PayPalMessageModalViewModel: NSObject, WKNavigationDelegate, WKScriptMessa
 
         var encodableDict: [String: AnyCodable] = [:]
         for (key, value) in eventArgs[0] {
-            encodableDict[key] = value as? AnyCodable
+            encodableDict[key] = AnyCodable(value)
         }
         logger.addEvent(.dynamic(data: encodableDict))
 


### PR DESCRIPTION
## Description

- Convert `Any` value to `AnyCodable` via direct `init`

## Screenshots

N/A

## Testing instructions

N/A
