### PR TITLE
refactor: rename stage environment value to develop

### DIFF
--- a/Demo/Demo/SwiftUIContentView.swift
+++ b/Demo/Demo/SwiftUIContentView.swift
@@ -42,7 +42,9 @@ struct SwiftUIContentView: View {
             )
         )
 
-        messageConfig.data.buyerCountry = buyerCountry
+        if !buyerCountry.isEmpty {
+            messageConfig.data.buyerCountry = buyerCountry
+        }
         messageConfig.data.ignoreCache = ignoreCache
 
         return messageConfig

--- a/Sources/PayPalMessages/Enums/Environment.swift
+++ b/Sources/PayPalMessages/Enums/Environment.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum Environment: Equatable {
-    case stage(host: String, devTouchpoint: Bool = false, stageTag: String? = nil)
+    case develop(host: String, devTouchpoint: Bool = false, stageTag: String? = nil)
     case sandbox
     case live
 
@@ -11,8 +11,8 @@ public enum Environment: Equatable {
             return "production"
         case .sandbox:
             return "sandbox"
-        case .stage:
-            return "stage"
+        case .develop:
+            return "develop"
         }
     }
 
@@ -20,7 +20,7 @@ public enum Environment: Equatable {
         switch self {
         case .live, .sandbox:
             return true
-        case .stage:
+        case .develop:
             return false
         }
     }
@@ -29,7 +29,7 @@ public enum Environment: Equatable {
         switch self {
         case .live, .sandbox:
             return URLSession.shared
-        case .stage:
+        case .develop:
             return URLSession(
                 configuration: .default,
                 delegate: DevelopmentSession(),
@@ -41,7 +41,7 @@ public enum Environment: Equatable {
     // swiftlint:disable force_unwrapping
     private var baseURL: URL {
         switch self {
-        case .stage(let host, _, _):
+        case .develop(let host, _, _):
             return URL(string: "https://www.\(host)")!
         case .sandbox:
             return URL(string: "https://www.sandbox.paypal.com")!
@@ -53,7 +53,7 @@ public enum Environment: Equatable {
     // swiftlint:disable force_unwrapping
     private var loggerBaseURL: URL {
         switch self {
-        case .stage(let host, _, _):
+        case .develop(let host, _, _):
             return URL(string: "https://api.\(host)")!
         case .sandbox:
             return URL(string: "https://api.sandbox.paypal.com")!
@@ -83,8 +83,8 @@ public enum Environment: Equatable {
         } else {
             basePath = baseURL
 
-            // Append dev_touchpoint and stage_tag query parameters only for .stage case
-            if case .stage(_, let devTouchpoint, let stageTag) = self {
+            // Append dev_touchpoint and stage_tag query parameters only for .develop case
+            if case .develop(_, let devTouchpoint, let stageTag) = self {
                 if devTouchpoint {
                     queryItems.append(URLQueryItem(name: "dev_touchpoint", value: "\(devTouchpoint)"))
                 }

--- a/Sources/PayPalMessages/PayPalMessageModalViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageModalViewModel.swift
@@ -214,7 +214,7 @@ class PayPalMessageModalViewModel: NSObject, WKNavigationDelegate, WKScriptMessa
         ) { _, _ in
             // TODO: Does the JS error text get returned here?
         }
-        
+
         queuedTimer?.invalidate()
     }
 
@@ -277,7 +277,7 @@ class PayPalMessageModalViewModel: NSObject, WKNavigationDelegate, WKScriptMessa
         switch environment {
         case .live, .sandbox:
             completionHandler(.performDefaultHandling, nil)
-        case .stage:
+        case .develop:
             guard let serverTrust = challenge.protectionSpace.serverTrust else {
                 return completionHandler(.performDefaultHandling, nil)
             }

--- a/Tests/PayPalMessagesTests/EnvironmentTests.swift
+++ b/Tests/PayPalMessagesTests/EnvironmentTests.swift
@@ -6,7 +6,7 @@ class EnvironmentTests: XCTestCase {
 
     // Test rawValue correctness
     func testRawValues() {
-        XCTAssertEqual(Environment.stage(host: "testhost").rawValue, "stage")
+        XCTAssertEqual(Environment.develop(host: "testhost").rawValue, "develop")
         XCTAssertEqual(Environment.sandbox.rawValue, "sandbox")
         XCTAssertEqual(Environment.live.rawValue, "production")
     }
@@ -15,12 +15,12 @@ class EnvironmentTests: XCTestCase {
     func testEnvironmentSetting() {
         XCTAssertTrue(Environment.live.isProduction)
         XCTAssertTrue(Environment.sandbox.isProduction)
-        XCTAssertFalse(Environment.stage(host: "testhost").isProduction)
+        XCTAssertFalse(Environment.develop(host: "testhost").isProduction)
     }
 
     // Test URL construction
     func testURLConstruction() {
-        let stageURL = Environment.stage(host: "testhost").url(.modal, ["param": "value"])
+        let stageURL = Environment.develop(host: "testhost").url(.modal, ["param": "value"])
         XCTAssertEqual(stageURL?.absoluteString, "https://www.testhost/credit-presentment/lander/modal?param=value")
 
         let sandboxURL = Environment.sandbox.url(.merchantProfile)


### PR DESCRIPTION
## Description

- Rename stage environment value to develop
- Filter empty buyer country string input into SwiftUI message demo that caused unexpected fetch when changing options that do not require a fetch (e.g. text align)

## Screenshots

N/A

## Testing instructions

1. Open the demo app SwiftUI view
2. Tap the `Left` or `Center` style option
3. Ensure that status in the bottom right does not change to `Loading...`
