### PR TITLE
refactor: include response details when message failure

### DIFF
--- a/PayPalMessages.xcodeproj/project.pbxproj
+++ b/PayPalMessages.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		C60F156A2B3C851100E16902 /* AnalyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60F15692B3C851100E16902 /* AnalyticsLogger.swift */; };
 		C61D84472B33348C00F372EF /* CloudEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61D84462B33348C00F372EF /* CloudEvent.swift */; };
+		C62FF8232B742C9400890823 /* ResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62FF8222B742C9400890823 /* ResponseError.swift */; };
+		C62FF8252B74315B00890823 /* ResponseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62FF8242B74315B00890823 /* ResponseErrorTests.swift */; };
 		C635F4362A9645B10096F9FF /* PayPalMessages.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C635F42E2A9645B10096F9FF /* PayPalMessages.framework */; };
 		C635F4C12A964A020096F9FF /* PayPalMessageModalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C635F48E2A964A020096F9FF /* PayPalMessageModalViewModel.swift */; };
 		C635F4C32A964A020096F9FF /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C635F4912A964A020096F9FF /* AnalyticsEvent.swift */; };
@@ -87,6 +89,8 @@
 /* Begin PBXFileReference section */
 		C60F15692B3C851100E16902 /* AnalyticsLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsLogger.swift; sourceTree = "<group>"; };
 		C61D84462B33348C00F372EF /* CloudEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudEvent.swift; sourceTree = "<group>"; };
+		C62FF8222B742C9400890823 /* ResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseError.swift; sourceTree = "<group>"; };
+		C62FF8242B74315B00890823 /* ResponseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseErrorTests.swift; sourceTree = "<group>"; };
 		C635F42E2A9645B10096F9FF /* PayPalMessages.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PayPalMessages.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C635F4352A9645B10096F9FF /* PayPalMessagesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PayPalMessagesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C635F48E2A964A020096F9FF /* PayPalMessageModalViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayPalMessageModalViewModel.swift; sourceTree = "<group>"; };
@@ -270,6 +274,7 @@
 				C635F4AA2A964A020096F9FF /* MessageResponse.swift */,
 				C635F4A72A964A020096F9FF /* MerchantProfileProvider.swift */,
 				C635F4A82A964A020096F9FF /* MerchantProfileRequest.swift */,
+				C62FF8222B742C9400890823 /* ResponseError.swift */,
 			);
 			path = IO;
 			sourceTree = "<group>";
@@ -345,6 +350,7 @@
 				F23BF3922AB8D8A70074FA00 /* PayPalMessageViewTests.swift */,
 				F23BF3942AB9CEDA0074FA00 /* PayPalMessageResponseTests.swift */,
 				F27522972AE056670092A3BF /* PayPalMessageConfigTests.swift */,
+				C62FF8242B74315B00890823 /* ResponseErrorTests.swift */,
 			);
 			path = PayPalMessagesTests;
 			sourceTree = "<group>";
@@ -510,6 +516,7 @@
 				C635F4E92A964A020096F9FF /* PayPalMessageDelegates.swift in Sources */,
 				C635F4CC2A964A020096F9FF /* BuildInfo.swift in Sources */,
 				C635F4E62A964A020096F9FF /* HTTPURLResponse.swift in Sources */,
+				C62FF8232B742C9400890823 /* ResponseError.swift in Sources */,
 				C635F4DD2A964A020096F9FF /* Proxy.swift in Sources */,
 				C635F4CF2A964A020096F9FF /* PayPalMessageColor.swift in Sources */,
 				C635F4C72A964A020096F9FF /* PayPalMessageConfig.swift in Sources */,
@@ -530,6 +537,7 @@
 				F23BF38B2AB8BAAC0074FA00 /* AnyCodableTests.swift in Sources */,
 				C635F5012A96524D0096F9FF /* PayPalMessageLogSenderMock.swift in Sources */,
 				C635F5062A96524D0096F9FF /* PayPalMessageViewModelTests.swift in Sources */,
+				C62FF8252B74315B00890823 /* ResponseErrorTests.swift in Sources */,
 				C635F5082A96524D0096F9FF /* MerchantProfileProviderTests.swift in Sources */,
 				F27522982AE056670092A3BF /* PayPalMessageConfigTests.swift in Sources */,
 				C635F5002A96524D0096F9FF /* PayPalMessageViewMock.swift in Sources */,

--- a/Sources/PayPalMessages/Enums/PayPalMessageError.swift
+++ b/Sources/PayPalMessages/Enums/PayPalMessageError.swift
@@ -1,10 +1,10 @@
 public enum PayPalMessageError: Error, Equatable {
     case invalidURL
-    case invalidResponse(paypalDebugID: String? = nil)
+    case invalidResponse(paypalDebugID: String? = nil, issue: String? = nil, description: String? = nil)
 
     public var paypalDebugId: String? {
         switch self {
-        case .invalidResponse(let paypalDebugID):
+        case .invalidResponse(let paypalDebugID, _, _):
             return paypalDebugID
 
         default:
@@ -12,16 +12,25 @@ public enum PayPalMessageError: Error, Equatable {
         }
     }
 
-    public var description: String? {
+    public var issue: String? {
         switch self {
         case .invalidURL:
             return "InvalidURL"
-        case .invalidResponse:
-            return "InvalidResponse"
+        case .invalidResponse(_, let issue, _):
+            return issue ?? "InvalidResponse"
+        }
+    }
+
+    public var description: String? {
+        switch self {
+        case .invalidURL:
+            return nil
+        case .invalidResponse(_, _, let description):
+            return description
         }
     }
 
     static public func == (lhs: PayPalMessageError, rhs: PayPalMessageError) -> Bool {
-        lhs.paypalDebugId == rhs.paypalDebugId && lhs.description == rhs.description
+        lhs.paypalDebugId == rhs.paypalDebugId && lhs.issue == rhs.issue && lhs.description == rhs.description
     }
 }

--- a/Sources/PayPalMessages/IO/MessageRequest.swift
+++ b/Sources/PayPalMessages/IO/MessageRequest.swift
@@ -74,28 +74,38 @@ class MessageRequest: MessageRequestable {
         let startingTimestamp = Date()
 
         log(.debug, "fetchMessage URL is \(url)")
+
         fetch(url, headers: headers, session: parameters.environment.urlSession) { data, response, _ in
+            let requestDuration = startingTimestamp.timeIntervalSinceNow
+
             guard let response = response as? HTTPURLResponse else {
                 onCompletion(.failure(.invalidResponse()))
                 return
             }
-            let requestDuration = startingTimestamp.timeIntervalSinceNow
 
-            guard response.statusCode == 200,
-                  let data,
-                  var messageResponse = try? JSONDecoder().decode(
-                    MessageResponse.self,
-                    from: data
-                  ) else {
-                onCompletion(.failure(
-                    .invalidResponse(paypalDebugID: response.paypalDebugID)
-                ))
-                return
+            switch response.statusCode {
+            case 200:
+                guard let data, var messageResponse = try? JSONDecoder().decode(MessageResponse.self, from: data) else {
+                    onCompletion(.failure(.invalidResponse(paypalDebugID: response.paypalDebugID)))
+                    return
+                }
+
+                messageResponse.requestDuration = requestDuration
+
+                onCompletion(.success(messageResponse))
+
+            default:
+                guard let data, let responseError = try? JSONDecoder().decode(ResponseError.self, from: data) else {
+                    onCompletion(.failure(.invalidResponse(paypalDebugID: response.paypalDebugID)))
+                    return
+                }
+
+                onCompletion(.failure(.invalidResponse(
+                    paypalDebugID: responseError.paypalDebugID,
+                    issue: responseError.issue,
+                    description: responseError.description
+                )))
             }
-
-            messageResponse.requestDuration = requestDuration
-
-            onCompletion(.success(messageResponse))
         }
     }
 }

--- a/Sources/PayPalMessages/IO/ResponseError.swift
+++ b/Sources/PayPalMessages/IO/ResponseError.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct ResponseError: Decodable {
+
+    let paypalDebugID: String
+    let issue: String?
+    let description: String?
+
+    init(paypalDebugID: String, issue: String?, description: String?) {
+        self.paypalDebugID = paypalDebugID
+        self.issue = issue
+        self.description = description
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case paypalDebugID = "debug_id"
+        case details
+    }
+
+    enum DetailsKeys: CodingKey {
+        case issue
+        case description
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        paypalDebugID = try container.decode(String.self, forKey: .paypalDebugID)
+
+        guard var detailsContainer = try? container.nestedUnkeyedContainer(forKey: .details) else {
+            issue = nil
+            description = nil
+
+            return
+        }
+
+        let detailContainer = try detailsContainer.nestedContainer(keyedBy: DetailsKeys.self)
+
+        issue = try detailContainer.decode(String.self, forKey: .issue)
+        description = try detailContainer.decode(String.self, forKey: .description)
+    }
+}

--- a/Sources/PayPalMessages/PayPalMessageModalViewModel.swift
+++ b/Sources/PayPalMessages/PayPalMessageModalViewModel.swift
@@ -214,7 +214,7 @@ class PayPalMessageModalViewModel: NSObject, WKNavigationDelegate, WKScriptMessa
         ) { _, _ in
             // TODO: Does the JS error text get returned here?
         }
-        
+
         queuedTimer?.invalidate()
     }
 

--- a/Tests/PayPalMessagesTests/PayPalMessageViewModelTests.swift
+++ b/Tests/PayPalMessagesTests/PayPalMessageViewModelTests.swift
@@ -73,7 +73,7 @@ final class PayPalMessageViewModelTests: XCTestCase {
         XCTAssertTrue(mockedDelegate.onErrorCalled)
         XCTAssertNil(viewModel.messageParameters)
 
-        guard case .invalidResponse(let paypalDebugID) = mockedDelegate.error else {
+        guard case .invalidResponse(let paypalDebugID, _, _) = mockedDelegate.error else {
             XCTFail("Expected error invalidResponse")
             return
         }

--- a/Tests/PayPalMessagesTests/ResponseErrorTests.swift
+++ b/Tests/PayPalMessagesTests/ResponseErrorTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+@testable import PayPalMessages
+import XCTest
+
+final class ResponseErrorTests: XCTestCase {
+
+    func testErrorWithoutDetails() throws {
+        let json = """
+        {
+            "name": "UNPROCESSABLE_ENTITY",
+            "message": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "debug_id": "12345"
+        }
+        """
+            // swiftlint:disable force_unwrapping
+            .data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let responseError = try decoder.decode(ResponseError.self, from: json)
+
+        XCTAssertEqual(responseError.paypalDebugID, "12345")
+        XCTAssertNil(responseError.issue)
+        XCTAssertNil(responseError.description)
+    }
+
+    func testErrorWithDetails() throws {
+        let json = """
+        {
+            "name": "UNPROCESSABLE_ENTITY",
+            "message": "The requested action could not be performed, semantically incorrect, or failed business validation.",
+            "debug_id": "12345",
+            "details": [
+                {
+                    "issue": "TEST_ISSUE",
+                    "description": "A helpful description."
+                }
+            ]
+        }
+        """
+            // swiftlint:disable force_unwrapping
+            .data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let responseError = try decoder.decode(ResponseError.self, from: json)
+
+        XCTAssertEqual(responseError.paypalDebugID, "12345")
+        XCTAssertEqual(responseError.issue, "TEST_ISSUE")
+        XCTAssertEqual(responseError.description, "A helpful description.")
+    }
+}


### PR DESCRIPTION
## Description

- If there is a message error due to a non-`200` response from the server, include the provided error details to help the user

## Screenshots

N/A

## Testing instructions

N/A
