### PR TITLE
docs: add Braintree SDK requirement disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PayPal iOS SDK Messages Module
 
-Welcome to the PayPal iOS SDK Messages Module. This package facilitates rendering PayPal messages to promote offers such as Pay Later and PayPal Credit to customers. **It is recommended to integrate this package using the [PayPal iOS SDK](https://github.com/paypal/paypal-ios)**.
+Welcome to the PayPal iOS SDK Messages Module. This package facilitates rendering PayPal messages to promote offers such as Pay Later and PayPal Credit to customers.
 
 > **Note:** This messaging component is intended for use with the **[Braintree SDK](https://developer.paypal.com/braintree/docs/guides/paypal/messaging/ios/v6)** only. To integrate PayPal messaging in your iOS app, you must have a Braintree account and the Braintree SDK integrated. PPCP SDK integrations are not supported.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the PayPal iOS SDK Messages Module. This package facilitates rendering PayPal messages to promote offers such as Pay Later and PayPal Credit to customers. **It is recommended to integrate this package using the [PayPal iOS SDK](https://github.com/paypal/paypal-ios)**.
 
+> **Note:** This messaging component is intended for use with the **[Braintree SDK](https://developer.paypal.com/braintree/docs/guides/paypal/messaging/ios/v6)** only. To integrate PayPal messaging in your iOS app, you must have a Braintree account and the Braintree SDK integrated. PPCP SDK integrations are not supported.
+
 **The PayPalMessages package permits a deployment target of iOS 14.0 or higher**. It requires Xcode 14.3+ and Swift 5.8+.
 
 ## Support 


### PR DESCRIPTION
## Summary
- Adds a note at the top of the README clarifying that this library is intended for use with the Braintree SDK only
- Merchants must have a Braintree account and the Braintree SDK integrated
- PPCP SDK integrations are not supported
- Links to the [Braintree iOS messaging docs](https://developer.paypal.com/braintree/docs/guides/paypal/messaging/ios/v6)

Addresses merchant/SE confusion around PPCP SDK compatibility.